### PR TITLE
Clear timer on component unmount

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,20 +14,24 @@ export function useStore(store, opts = {}) {
   }
 
   useEffect(() => {
-    let batching
+    let batching, timer, unlisten
     let rerender = () => {
       if (!batching) {
         batching = 1
-        setTimeout(() => {
+        timer = setTimeout(() => {
           batching = undefined
           forceRender({})
         })
       }
     }
     if (opts.keys) {
-      return listenKeys(store, opts.keys, rerender)
+      unlisten = listenKeys(store, opts.keys, rerender)
     } else {
-      return store.listen(rerender)
+      unlisten = store.listen(rerender)
+    }
+    return () => {
+      unlisten()
+      clearTimeout(timer)
     }
   }, [store, '' + opts.keys])
 


### PR DESCRIPTION
Without this, the forceRender may execute on unmounted component. It can happen when the component presence is depends on the store and the component itself is also dependent on store.

The @nanostores/react has the same problem.