### PR TITLE
Fix typo `react`→`preact`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export interface UseStoreOptions<
  * Can be user with store builder too.
  *
  * ```js
- * import { useStore } from 'nanostores/react'
+ * import { useStore } from 'nanostores/preact'
  *
  * import { router } from '../store/router'
  *
@@ -45,7 +45,7 @@ export function useStore<
  * with fix for React Native.
  *
  * ```js
- * import { batch } from 'nanostores/react'
+ * import { batch } from 'nanostores/preact'
  *
  * React.useEffect(() => {
  *   let unbind = store.listen(() => {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "author": "Andrey Sitnik <andrey@sitnik.ru>",
   "license": "MIT",
-  "repository": "nanostores/react",
+  "repository": "nanostores/preact",
   "sideEffects": false,
   "type": "module",
   "types": "./index.d.ts",


### PR DESCRIPTION
Spotted small typo while upgrading my dependencies, link to repo is pointing to React, instead of Preact. 
![Screenshot 2022-09-22 at 14 32 57](https://user-images.githubusercontent.com/836813/191748835-73320aba-9088-4221-b57a-0f2f2bab8d6f.png)
 