### PR TITLE
[0.4.1] - fix store updating between render and effect

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,12 @@ import { listenKeys } from 'nanostores'
 
 export function useStore(store, opts = {}) {
   let [, forceRender] = useState({})
+  let [valueBeforeEffect] = useState(store.get())
 
+  useEffect(() => {
+    valueBeforeEffect !== store.get() && forceRender({})
+  }, [])
+  
   useEffect(() => {
     let batching, timer, unlisten
     let rerender = () => {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "index.js": "{ useStore }",
         "nanostores": "{ map, computed }"
       },
-      "limit": "973 B"
+      "limit": "995 B"
     }
   ]
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -220,4 +220,42 @@ test('has keys option', async () => {
   equal(renderCount, 4)
 })
 
+test('return correct value for Atom, if store was changed between rendering and useEffect', async () => {
+  let store = atom<'old' | 'new'>('old')
+
+  let renderWithMutate = (value: string): string => {
+    store.get() !== 'new' && store.set('new')
+    return value
+  }
+
+  let Wrapper: FC = () => {
+    let value = useStore(store)
+    return h('p', {}, renderWithMutate(value))
+  }
+
+  render(h(Wrapper, null))
+
+  let result = screen.getByText('new').textContent
+  equal(result, 'new')
+})
+
+test('return correct value for MapStore, if store was changed between rendering and useEffect', async () => {
+  let store = map<{ value: 'old' | 'new' }>({ value: 'old' })
+
+  let renderWithMutate = (value: string): string => {
+    store.get().value !== 'new' && store.setKey('value', 'new')
+    return value
+  }
+
+  let Wrapper: FC = () => {
+    let value = useStore(store).value
+    return h('p', {}, renderWithMutate(value))
+  }
+
+  render(h(Wrapper, null))
+
+  let result = screen.getByText('new').textContent
+  equal(result, 'new')
+})
+
 test.run()


### PR DESCRIPTION
A quick store change that occurs between the component's first render and the first useEffect does not update the component. An additional useEffect has been added for the solution. It will compare the actual value of the store and the value at first render. If values incomparable, component will be updated