### PR TITLE
Make useStore compatible with client-side hydration of SSR components

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,31 @@ export const Header = () => {
 }
 ```
 
+Use the `keys` option to re-render only on specific key changes:
+
+```tsx
+export const Header = () => {
+  const profile = useStore($profile, { keys: 'name' })
+  return <header>{profile.name}</header>
+}
+```
+
+Use the `initial` option to avoid hydration errors on Server Side Rendered (SSR) pages that can get out of sync with the client-side store value:
+
+```tsx
+import { map } from '@nanostores'
+import { useStore } from '@nanostores/preact'
+
+const INITIAL_PROFILE = { name: 'anonymous' }
+
+const $profile = map(INITIAL_PROFILE)
+
+export const Header = () => {
+  const profile = useStore($profile, { initial: INITIAL_PROFILE })
+  return <header>{profile.name}</header>
+}
+```
+
 [Nano Stores]: https://github.com/nanostores/nanostores/
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,22 +34,6 @@ export const Header = () => {
 }
 ```
 
-Use the `initial` option to avoid hydration errors on Server Side Rendered (SSR) pages that can get out of sync with the client-side store value:
-
-```tsx
-import { map } from '@nanostores'
-import { useStore } from '@nanostores/preact'
-
-const INITIAL_PROFILE = { name: 'anonymous' }
-
-const $profile = map(INITIAL_PROFILE)
-
-export const Header = () => {
-  const profile = useStore($profile, { initial: INITIAL_PROFILE })
-  return <header>{profile.name}</header>
-}
-```
-
 [Nano Stores]: https://github.com/nanostores/nanostores/
 
 ---

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,10 @@ type StoreKeys<T> = T extends { setKey: (k: infer K, v: any) => unknown }
 
 export interface UseStoreOptions<SomeStore> {
   /**
+   * Value to return before hydration, to avoid hydration errors with SSR.
+   */
+  initial?: StoreValue<SomeStore>
+  /**
    * Will re-render components only on specific key changes.
    */
   keys?: StoreKeys<SomeStore>[]

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,10 +6,6 @@ type StoreKeys<T> = T extends { setKey: (k: infer K, v: any) => unknown }
 
 export interface UseStoreOptions<SomeStore> {
   /**
-   * Value to return before hydration, to avoid hydration errors with SSR.
-   */
-  initial?: StoreValue<SomeStore>
-  /**
    * Will re-render components only on specific key changes.
    */
   keys?: StoreKeys<SomeStore>[]

--- a/index.js
+++ b/index.js
@@ -4,11 +4,10 @@ import { useEffect, useState } from 'preact/hooks'
 export function useStore(store, opts = {}) {
   let [hydrated, setHydrated] = useState(false)
   let [, forceRender] = useState({})
-  let [valueBeforeEffect] = useState(store.get())
 
+  // A re-render is always forced on mount and hydrate
   useEffect(() => {
     setHydrated(true)
-    valueBeforeEffect !== store.get() && forceRender({})
   }, [])
 
   useEffect(() => {

--- a/index.js
+++ b/index.js
@@ -2,13 +2,15 @@ import { listenKeys } from 'nanostores'
 import { useEffect, useState } from 'preact/hooks'
 
 export function useStore(store, opts = {}) {
+  let [hydrated, setHydrated] = useState(false)
   let [, forceRender] = useState({})
   let [valueBeforeEffect] = useState(store.get())
 
   useEffect(() => {
+    'initial' in opts && setHydrated(true)
     valueBeforeEffect !== store.get() && forceRender({})
   }, [])
-  
+
   useEffect(() => {
     let batching, timer, unlisten
     let rerender = () => {
@@ -31,5 +33,5 @@ export function useStore(store, opts = {}) {
     }
   }, [store, '' + opts.keys])
 
-  return store.get()
+  return !hydrated && 'initial' in opts ? opts.initial : store.get()
 }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ export function useStore(store, opts = {}) {
   let [valueBeforeEffect] = useState(store.get())
 
   useEffect(() => {
-    'initial' in opts && setHydrated(true)
+    setHydrated(true)
     valueBeforeEffect !== store.get() && forceRender({})
   }, [])
 
@@ -33,5 +33,6 @@ export function useStore(store, opts = {}) {
     }
   }, [store, '' + opts.keys])
 
-  return !hydrated && 'initial' in opts ? opts.initial : store.get()
+  // `'init' in store` check for compatibility with nanostores <= 1.1.1
+  return !hydrated && 'init' in store ? store.init : store.get()
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "nanodelay": "^2.0.2",
     "nanostores": "^1.0.1",
     "preact": "^10.26.5",
+    "preact-render-to-string": "^6.6.6",
     "size-limit": "^11.2.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "index.js": "{ useStore }",
         "nanostores": "{ map, computed }"
       },
-      "limit": "960 B"
+      "limit": "943 B"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "index.js": "{ useStore }",
         "nanostores": "{ map, computed }"
       },
-      "limit": "922 B"
+      "limit": "952 B"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "index.js": "{ useStore }",
         "nanostores": "{ map, computed }"
       },
-      "limit": "952 B"
+      "limit": "960 B"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       preact:
         specifier: ^10.26.5
         version: 10.26.5
+      preact-render-to-string:
+        specifier: ^6.6.6
+        version: 6.6.6(preact@10.26.5)
       size-limit:
         specifier: ^11.2.0
         version: 11.2.0
@@ -1372,6 +1375,11 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  preact-render-to-string@6.6.6:
+    resolution: {integrity: sha512-EfqZJytnjJldV+YaaqhthU2oXsEf5e+6rDv957p+zxAvNfFLQOPfvBOTncscQ+akzu6Wrl7s3Pa0LjUQmWJsGQ==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
 
   preact@10.26.5:
     resolution: {integrity: sha512-fmpDkgfGU6JYux9teDWLhj9mKN55tyepwYbxHgQuIxbWQzgFg5vk7Mrrtfx7xRxq798ynkY4DDDxZr235Kk+4w==}
@@ -2976,6 +2984,10 @@ snapshots:
   picomatch@4.0.2: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  preact-render-to-string@6.6.6(preact@10.26.5):
+    dependencies:
+      preact: 10.26.5
 
   preact@10.26.5: {}
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,7 +6,8 @@ import { atom, map, onMount, STORE_UNMOUNT_DELAY } from 'nanostores'
 import { deepStrictEqual, equal } from 'node:assert'
 import { afterEach, test } from 'node:test'
 import type { FunctionalComponent as FC } from 'preact'
-import { h } from 'preact'
+import { h, hydrate } from 'preact'
+import { renderToString } from 'preact-render-to-string'
 import { useState } from 'preact/hooks'
 
 import { useStore } from '../index.js'
@@ -260,25 +261,18 @@ test('returns initial value until hydrated', () => {
   let atomStore = atom<Value>('old')
   let mapStore = map<{ value: Value }>({ value: 'old' })
 
-  atomStore.set('new')
-  mapStore.set({ value: 'new' })
-
   let atomValues: Value[] = [] // Track values used across renders
-  let atomRenders = 0
 
   let AtomTest: FC = () => {
     let value = useStore(atomStore)
-    atomRenders += 1
     atomValues.push(value)
     return h('div', { 'data-testid': 'atom-test' }, value)
   }
 
   let mapValues: Value[] = [] // Track values used across renders
-  let mapRenders = 0
 
   let MapTest: FC = () => {
     let value = useStore(mapStore).value
-    mapRenders += 1
     mapValues.push(value)
     return h('div', { 'data-testid': 'map-test' }, value)
   }
@@ -292,20 +286,29 @@ test('returns initial value until hydrated', () => {
     )
   }
 
-  render(h(Wrapper, null))
+  // Create a "server" rendered element to re-hydrate
+  let ssrElement = document.createElement('div')
+  document.body.appendChild(ssrElement)
+  let html = renderToString(h(Wrapper, null))
+  ssrElement.innerHTML = html
 
-  // Confirm components were each rendered twice
-  equal(atomRenders, 2)
-  equal(mapRenders, 2)
+  equal(screen.getByTestId('atom-test').textContent, 'old')
+  equal(screen.getByTestId('map-test').textContent, 'old')
 
-  // Confirm initial render got old values, and subsequent post-hydration
-  // render got new values
-  deepStrictEqual(atomValues, ['old', 'new'])
-  deepStrictEqual(mapValues, ['old', 'new'])
+  // Simulate store state change on client-side, after "server" render
+  atomStore.set('new')
+  mapStore.set({ value: 'new' })
 
-  // Confirm final rendered version has new values
-  let atomResult = screen.getByTestId('atom-test').textContent
-  equal(atomResult, 'new')
-  let mapResult = screen.getByTestId('map-test').textContent
-  equal(mapResult, 'new')
+  // Hydrate into SSR element
+  act(() => {
+    hydrate(h(Wrapper, null), ssrElement)
+  })
+
+  // Confirm "server" render got old values, initial client render got old
+  // values at hydration, then post-hydration render got new values
+  deepStrictEqual(atomValues, ['old', 'old', 'new'])
+  deepStrictEqual(mapValues, ['old', 'old', 'new'])
+
+  equal(screen.getByTestId('atom-test').textContent, 'new')
+  equal(screen.getByTestId('map-test').textContent, 'new')
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -60,7 +60,7 @@ test('renders simple store', async () => {
   deepStrictEqual(events, ['constructor'])
   equal(screen.getByTestId('test1').textContent, 'a')
   equal(screen.getByTestId('test2').textContent, 'a')
-  equal(renders, 1)
+  equal(renders, 2)
 
   await act(async () => {
     letter.set('b')
@@ -70,13 +70,13 @@ test('renders simple store', async () => {
 
   equal(screen.getByTestId('test1').textContent, 'c')
   equal(screen.getByTestId('test2').textContent, 'c')
-  equal(renders, 2)
+  equal(renders, 3)
 
   act(() => {
     screen.getByRole('button').click()
   })
   equal(screen.queryByTestId('test'), null)
-  equal(renders, 2)
+  equal(renders, 3)
   await delay(STORE_UNMOUNT_DELAY)
 
   deepStrictEqual(events, ['constructor', 'destroy'])
@@ -178,7 +178,7 @@ test('has keys option', async () => {
   render(h(Wrapper, {}, h(MapTest, {})))
 
   equal(screen.getByTestId('map-test').textContent, 'map:undefined-undefined')
-  equal(renderCount, 1)
+  equal(renderCount, 2)
 
   // updates on init
   await act(async () => {
@@ -187,7 +187,7 @@ test('has keys option', async () => {
   })
 
   equal(screen.getByTestId('map-test').textContent, 'map:undefined-undefined')
-  equal(renderCount, 2)
+  equal(renderCount, 3)
 
   // updates when has key
   await act(async () => {
@@ -196,7 +196,7 @@ test('has keys option', async () => {
   })
 
   equal(screen.getByTestId('map-test').textContent, 'map:a-undefined')
-  equal(renderCount, 3)
+  equal(renderCount, 4)
 
   // does not update when has no key
   await act(async () => {
@@ -205,7 +205,7 @@ test('has keys option', async () => {
   })
 
   equal(screen.getByTestId('map-test').textContent, 'map:a-undefined')
-  equal(renderCount, 3)
+  equal(renderCount, 4)
 
   // reacts on parameter changes
   await act(async () => {
@@ -214,7 +214,7 @@ test('has keys option', async () => {
   })
 
   equal(screen.getByTestId('map-test').textContent, 'map:a-b')
-  equal(renderCount, 4)
+  equal(renderCount, 5)
 })
 
 test('supports atom changes between rendering and useEffect', () => {
@@ -255,7 +255,7 @@ test('supports map changes between rendering and useEffect', () => {
   equal(result, 'new')
 })
 
-test('returns initial value until hydrated, per completed useEffect', () => {
+test('returns initial value until hydrated', () => {
   type Value = 'new' | 'old'
   let atomStore = atom<Value>('old')
   let mapStore = map<{ value: Value }>({ value: 'old' })
@@ -264,17 +264,21 @@ test('returns initial value until hydrated, per completed useEffect', () => {
   mapStore.set({ value: 'new' })
 
   let atomValues: Value[] = [] // Track values used across renders
+  let atomRenders = 0
 
   let AtomTest: FC = () => {
-    let value = useStore(atomStore, { initial: 'old' })
+    let value = useStore(atomStore)
+    atomRenders += 1
     atomValues.push(value)
     return h('div', { 'data-testid': 'atom-test' }, value)
   }
 
   let mapValues: Value[] = [] // Track values used across renders
+  let mapRenders = 0
 
   let MapTest: FC = () => {
-    let value = useStore(mapStore, { initial: { value: 'old' } }).value
+    let value = useStore(mapStore).value
+    mapRenders += 1
     mapValues.push(value)
     return h('div', { 'data-testid': 'map-test' }, value)
   }
@@ -289,6 +293,10 @@ test('returns initial value until hydrated, per completed useEffect', () => {
   }
 
   render(h(Wrapper, null))
+
+  // Confirm components were each rendered twice
+  equal(atomRenders, 2)
+  equal(mapRenders, 2)
 
   // Confirm initial render got old values, and subsequent post-hydration
   // render got new values

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -254,3 +254,50 @@ test('supports map changes between rendering and useEffect', () => {
   let result = screen.getByText('new').textContent
   equal(result, 'new')
 })
+
+test('returns initial value until hydrated, per completed useEffect', () => {
+  type Value = 'new' | 'old'
+  let atomStore = atom<Value>('old')
+  let mapStore = map<{ value: Value }>({ value: 'old' })
+
+  atomStore.set('new')
+  mapStore.set({ value: 'new' })
+
+  let atomValues: Value[] = [] // Track values used across renders
+
+  let AtomTest: FC = () => {
+    let value = useStore(atomStore, { initial: 'old' })
+    atomValues.push(value)
+    return h('div', { 'data-testid': 'atom-test' }, value)
+  }
+
+  let mapValues: Value[] = [] // Track values used across renders
+
+  let MapTest: FC = () => {
+    let value = useStore(mapStore, { initial: { value: 'old' } }).value
+    mapValues.push(value)
+    return h('div', { 'data-testid': 'map-test' }, value)
+  }
+
+  let Wrapper: FC = () => {
+    return h(
+      'div',
+      { 'data-testid': 'test' },
+      h(AtomTest, null),
+      h(MapTest, null)
+    )
+  }
+
+  render(h(Wrapper, null))
+
+  // Confirm initial render got old values, and subsequent post-hydration
+  // render got new values
+  deepStrictEqual(atomValues, ['old', 'new'])
+  deepStrictEqual(mapValues, ['old', 'new'])
+
+  // Confirm final rendered version has new values
+  let atomResult = screen.getByTestId('atom-test').textContent
+  equal(atomResult, 'new')
+  let mapResult = screen.getByTestId('map-test').textContent
+  equal(mapResult, 'new')
+})


### PR DESCRIPTION
Hi, please consider improving support for projects that use SSR / ISR pages with client-side navigation, which can currently get hydration errors without [a work-around like this](https://github.com/nanostores/react/issues/38#issuecomment-4015653114).

Add `initial` option to return same value as used for SSR until client-side hydration is complete

When a value is provided for the new optional `initial` option, that value is returned by `useStore` instead of the store's current value until hydration is completed on the client, as detected by completion of the first-run `useEffect`.

This `initial` option avoids hydration errors on projects that use Server Side Rendering (SSR) combined with client-side navigation and rendering, where the client-side store value can get out of sync with the value in the server-rendered page especially if the server page is cached in any way (ISR).